### PR TITLE
add post rotate callbacks

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The LogRoller.jl package is licensed under the MIT "Expat" License:
 
-> Copyright (c) 2019-2020: Tanmay Mohapatra
+> Copyright (c) 2019-2020: Tanmay Mohapatra, Julia Computing
 >
 > Permission is hereby granted, free of charge, to any person obtaining
 > a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 [![Coverage Status](https://coveralls.io/repos/github/tanmaykm/LogRoller.jl/badge.svg?branch=master)](https://coveralls.io/github/tanmaykm/LogRoller.jl?branch=master)
 
 Provides:
-- `RollingFileWriter` - `IO` implementation to a file writer that rotates files based on file size
-- `RollingLogger` - `AbstractLogger` implementation that uses a `RollingFileWriter` for output
+- `RollingFileWriter` - `IO` implementation to a file writer that rotates files based on file size.
+- `RollingLogger` - `AbstractLogger` implementation that uses a `RollingFileWriter` for output.
+- `postrotate` - Registers a callback function to be invoked with the rotated file name just after the current log file is rotated. The file name of the rotated file is passed as an argument. The function is blocking and so any lengthy operation that needs to be done should be done asynchronously.
+
 
 ## `RollingFileWriter`
 
@@ -70,6 +72,11 @@ Using `RollingLogger`
 julia> using Logging, LogRoller
 
 julia> logger = RollingLogger("/tmp/mylog.log", 1000, 3, Logging.Debug);
+
+julia> postrotate(logger) do rotatedfile
+           # e.g. code to upload file to permanent store
+           # ...
+       end
 
 julia> with_logger(logger) do
        @info("Hello RollingLogger")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,9 +145,6 @@ function test_process_streams()
         io = RollingFileWriter(filepath, 1000, 3)
         @test isfile(filepath)
 
-        #procstream = rawhandle(io)
-        #@test isa(procstream, Base.PipeEndpoint)
-
         julia = joinpath(Sys.BINDIR, "julia")
         cmd = pipeline(`$julia -e 'println("-"^100)'`; stdout=io, stderr=io)
         run(cmd)
@@ -171,6 +168,53 @@ function test_process_streams()
     end
 end
 
+function test_postrotate()
+    mktempdir() do logdir
+        filename = "test.log"
+        filepath = joinpath(logdir, filename)
+        @test !isfile(filepath)
+        @test !isfile(rolledfile(filepath, 1))
+        @test !isfile(rolledfile(filepath, 2))
+        @test !isfile(rolledfile(filepath, 3))
+
+        # initialize
+        logger = RollingLogger(filepath, 1000, 3)
+        rotatedfiles = Vector{String}()
+        postrotate(logger) do rotatedfilename
+            push!(rotatedfiles, rotatedfilename)
+        end
+        @test isfile(filepath)
+        logstr = "-"^40 # account for headers added by logger
+
+        # not rolled yet
+        with_logger(logger) do
+            @info(logstr)
+        end
+        @test !isfile(rolledfile(filepath, 1))
+        @test !isfile(rolledfile(filepath, 2))
+        @test !isfile(rolledfile(filepath, 3))
+
+        # roll once
+        with_logger(logger) do
+            for count in 1:10
+                @info(logstr)
+            end
+        end
+        @test isfile(filepath)
+        @test isfile(rolledfile(filepath, 1))
+        @test !isfile(rolledfile(filepath, 2))
+        @test !isfile(rolledfile(filepath, 3))
+        @test stat(filepath).size > 0
+        @test stat(filepath).size < 1000
+        @test stat(rolledfile(filepath, 1)).size > 0
+        @test stat(rolledfile(filepath, 1)).size < 1000  # compressed
+
+        @test length(rotatedfiles) == 1
+        @test rotatedfiles[1] == rolledfile(filepath, 1)
+    end
+end
+
 test_filewriter()
 test_logger()
 test_process_streams()
+test_postrotate()


### PR DESCRIPTION
Added a new exported function `postrotate` that can be used to register a callback function to be invoked with the rotated file name just after the current log file is rotated. The file name of the rotated file is passed as an argument. The function is blocking and so any lengthy operation that needs to be done should be done asynchronously. Callbacks can be registered with both RollingFileWriter and RollingLogger instances. E.g.:

```julia
julia> postrotate(logger) do rotatedfile
           # e.g. code to upload file to permanent store
           # ...
       end
```