### PR TITLE
fix tests for Julia 1.6 nightlies, param name style

### DIFF
--- a/src/LogRoller.jl
+++ b/src/LogRoller.jl
@@ -40,11 +40,11 @@ mutable struct RollingFileWriter <: IO
     assumed_level::LogLevel
     postrotate::Union{Nothing,Function}
 
-    function RollingFileWriter(filename::String, sizelimit::Int, nfiles::Int; rotateOnInit=false)
+    function RollingFileWriter(filename::String, sizelimit::Int, nfiles::Int; rotate_on_init=false)
         stream = open(filename, "a")
         filesize = stat(stream).size
         io = new(filename, sizelimit, nfiles, filesize, stream, ReentrantLock(), nothing, nothing, nothing, Logging.Info, nothing)
-        if rotateOnInit && filesize > 0
+        if rotate_on_init && filesize > 0
             rotate_file(io)
         end
         return io
@@ -189,8 +189,8 @@ mutable struct RollingLogger <: AbstractLogger
     format::Symbol
     entry_size_limit::Int
 end
-function RollingLogger(filename::String, sizelimit::Int, nfiles::Int, level=Logging.Info; timestamp_identifier::Symbol=:time, format::Symbol=:console, entry_size_limit::Int=DEFAULT_MAX_LOG_ENTRY_SIZE, rotateOnInit=false)
-    stream = RollingFileWriter(filename, sizelimit, nfiles,rotateOnInit=rotateOnInit)
+function RollingLogger(filename::String, sizelimit::Int, nfiles::Int, level=Logging.Info; timestamp_identifier::Symbol=:time, format::Symbol=:console, entry_size_limit::Int=DEFAULT_MAX_LOG_ENTRY_SIZE, rotate_on_init=false)
+    stream = RollingFileWriter(filename, sizelimit, nfiles, rotate_on_init=rotate_on_init)
     RollingLogger(stream, level, Dict{Any,Int}(), timestamp_identifier, format, entry_size_limit)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,7 +160,7 @@ function test_logger()
         @test stat(rolledfile(filepath, 3)).size < 1000  # compressed
 
         rm(rolledfile(filepath, 1))
-        logger_roi = RollingLogger(filepath, 1000, 3, rotateOnInit=true)
+        logger_roi = RollingLogger(filepath, 1000, 3, rotate_on_init=true)
         @test isfile(filepath)
         @test isfile(rolledfile(filepath, 1))
 


### PR DESCRIPTION
- fix tests for Julia 1.6 nightlies
- snake case parameter name for rotate on init