### PR TITLE
fix exception stack traces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c41e01d8-14e5-11ea-185b-e7eabed7be4b"
 keywords = ["log", "rotate", "roller", "logrotate"]
 license = "MIT"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.4.1"
+version = "0.4.2"
 
 [compat]
 julia = "1.2,1.3,1.4,1.5"

--- a/src/LogRoller.jl
+++ b/src/LogRoller.jl
@@ -258,7 +258,9 @@ function handle_message(logger::RollingLogger, level, message, _module, group, i
             end
             for (key, val) in kwargs
                 kwarg_timestamp && (key === logger.timestamp_identifier) && continue
-                println(iob, "│   ", key, " = ", val)
+                print(iob, "│   ", key, " = ")
+                Logging.showvalue(iob, val)
+                println(iob)
             end
             println(iob, "└ @ ", something(_module, "nothing"), " ", something(filepath, "nothing"), ":", something(line, "nothing"))
         catch ex

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -361,7 +361,7 @@ function test_json_format()
 
             entry = JSON.parse(readio)
             @test entry["metadata"]["level"] == "Info"
-            @test endswith(entry["message"], "Array{Bool,1}") # either "Array{Bool,1}" or "Vector{Bool} = Array{Bool,1}"
+            @test endswith(entry["message"], "Array{Bool,1}") || startswith(entry["message"], "Vector{Bool}") # either "Array{Bool,1}" or "Vector{Bool} = Array{Bool,1} or Vector{Bool} (alias for...)"
 
             entry = JSON.parse(readio)
             @test entry["metadata"]["level"] == "Error"


### PR DESCRIPTION
Use `Logging.showvalue` to print exception stack traces for console format logging properly. This was already handled for JSON format logs. Added some tests to verify proper exception printing in both JSON and console formatted outputs.