### PR TITLE
1.11 showvalue is now in BaseCoreLogging

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c41e01d8-14e5-11ea-185b-e7eabed7be4b"
 keywords = ["log", "rotate", "roller", "logrotate"]
 license = "MIT"
 authors = ["Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [compat]
 julia = "1.8"

--- a/src/LogRoller.jl
+++ b/src/LogRoller.jl
@@ -3,13 +3,12 @@ module LogRoller
 using Dates
 using Logging
 using CodecZlib
-using Logging
 using JSON
 using JSON.Serializations: CommonSerialization, StandardSerialization
 using JSON.Writer: StructuralContext
 import JSON: show_json
 
-import Logging: Logging, shouldlog, min_enabled_level, catch_exceptions, handle_message
+import Logging: shouldlog, min_enabled_level, catch_exceptions, handle_message
 import Base: write, close, rawhandle
 export RollingLogger, RollingFileWriter, postrotate
 

--- a/src/LogRoller.jl
+++ b/src/LogRoller.jl
@@ -9,12 +9,14 @@ using JSON.Serializations: CommonSerialization, StandardSerialization
 using JSON.Writer: StructuralContext
 import JSON: show_json
 
-import Logging: shouldlog, min_enabled_level, catch_exceptions, handle_message
+import Logging: Logging, shouldlog, min_enabled_level, catch_exceptions, handle_message
 import Base: write, close, rawhandle
 export RollingLogger, RollingFileWriter, postrotate
 
 const BUFFSIZE = 1024*16  # try and read 16K pages when possible
 const DEFAULT_MAX_LOG_ENTRY_SIZE = 256*1024
+
+const showvalue = VERSION ≥ v"1.11.0-DEV.1786" ? Base.CoreLogging.showvalue : Logging.showvalue
 
 include("limitio.jl")
 include("log_utils.jl")
@@ -223,7 +225,7 @@ function handle_message(logger::RollingLogger, level, message, _module, group, i
             for (key, val) in kwargs
                 kwarg_timestamp && (key === logger.timestamp_identifier) && continue
                 print(iob, "│   ", key, " = ")
-                Logging.showvalue(iob, val)
+                showvalue(iob, val)
                 println(iob)
             end
             println(iob, "└ @ ", something(_module, "nothing"), " ", something(filepath, "nothing"), ":", something(line, "nothing"))


### PR DESCRIPTION
`showvalue` is now in Base.CoreLogging after https://github.com/JuliaLang/julia/pull/54428

same fix as https://github.com/julia-actions/GitHubActions.jl/pull/37